### PR TITLE
Add variant options for OS and setup with docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 fix-ssh-on-pi.ini
 wpa_supplicant.conf
+raspberry-key-*
+raspbian_image.zip
+*-*-*-raspios-*-armhf-*.img

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 fix-ssh-on-pi.ini
 wpa_supplicant.conf
-raspberry-key-*
+.ssh/
 raspbian_image.zip
 *-*-*-raspios-*-armhf-*.img
+all_pies.ini

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Example for `fix-ssh-on-pi.ini`  :
 ```
 root_password_clear='CHANGEME'
 pi_password_clear='CHANGEME'
-public_key_file="/data/.ssh/raspberry-key-ed25519.pub"
-wifi_file="/data/wpa_supplicant.conf"
-first_boot="firstboot.sh"
-os_variant="full"
+public_key_file='/data/.ssh/raspberry-key-ed25519.pub'
+wifi_file='/data/wpa_supplicant.conf'
+first_boot='firstboot.sh'
+os_variant='full'
 ```
 
 ### Generate the image with ssh enabled :
@@ -69,7 +69,17 @@ docker run -ti --privileged -v /dev:/dev -v $(pwd):/data --workdir /data debian:
 
 ### Burn the image on a sd card :
 
-You can now burn the new file that finish by `-ssh-enabled.img` with the tool of your choice, insert into your raspberry and launch it.
+You can now burn the new file that finish by `-ssh-enabled.img` with the tool of your choice, insert the sdcard into your raspberry and launch it.
+
+Please check [index.md](https://github.com/kenfallon/fix-ssh-on-pi/blob/master/index.md).
+
+TLDR; here is an example with dd :
+
+```
+sudo fdisk -l 	   //  lists all the disks & partitions to get path of the sdcard
+sudo diskutil list // Same on Mac
+dd bs=4M if=FIXME-ssh-enabled.img of=/path/to/disk status=progress`
+```
 
 ### Setup the inventory for ansible :
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ os_variant='full'
 docker run -ti --privileged -v /dev:/dev -v $(pwd):/data --workdir /data debian:stable /bin/bash -c "apt update && apt install -y build-essential net-tools wget p7zip-full python3 && bash /data/fix-ssh-on-pi.bash"
 ```
 
+Note : the ugly option `-v /dev:/dev` seem to be needed (check [here](https://github.com/moby/moby/issues/27886) for more information). Without that, the losetup command does not successfully retrieve the partition table and create device.
+
 ### Burn the image on a sd card :
 
 You can now burn the new file that finish by `-ssh-enabled.img` with the tool of your choice, insert the sdcard into your raspberry and launch it.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,53 @@ Since then I improved the script to:
 - Creation of a [First Boot](https://github.com/nmcclain/raspberian-firstboot) script.
 
 This script is part of a series "Manage your Raspberry Pi fleet with Ansible" which was covered on [opensource.com](https://opensource.com/article/20/9/raspberry-pi-ansible) and on [Hacker Public Radio](http://hackerpublicradio.org/eps.php?id=3173).
+
+## Easy usage/setup with docker : 
+
+### Retrieve everything :
+
+If you're using mac or any system that does not support `losetup`, this can be a little bit painfull to use.
+
+Here's a process setup everything easily :
+
+```
+git clone git@github.com:kenfallon/fix-ssh-on-pi.git
+cd fix-ssh-on-pi
+```
+
+### Create a new ssh key for the Raspberry Pi :
+
+```
+docker run -v $(pwd):/data debian:stable /bin/bash -c "apt update && apt install -y openssh-client && ssh-keygen -t ed25519 -N '' -f /data/raspberry-key-ed25519 -C 'Raspberry Pi keys'"
+```
+
+### Edit configuration files :
+
+```
+cp wpa_supplicant.conf_example wpa_supplicant.conf
+cp fix-ssh-on-pi.ini_example fix-ssh-on-pi.ini
+```
+
+You should now edit both `wpa_supplicant.conf` and `fix-ssh-on-pi.ini` with the values that fits your need. 
+
+Example for `fix-ssh-on-pi.ini`  :
+
+```
+root_password_clear='CHANGEME'
+pi_password_clear='CHANGEME'
+public_key_file="/data/raspberry-key-ed25519.pub"
+wifi_file="/data/wpa_supplicant.conf"
+first_boot="firstboot.sh"
+os_variant=full
+```
+
+### Generate the image with ssh enabled :
+
+```
+docker run -ti --privileged -v /dev:/dev -v $(pwd):/data --workdir /data debian:stable /bin/bash -c "apt update && apt install -y build-essential net-tools wget p7zip-full python3 && bash /data/fix-ssh-on-pi.bash"
+```
+
+
+### Burn the image on a sd card :
+
+You can now burn the new file that finish by `-ssh-enabled.img` with the tool of your choice.

--- a/firstboot.sh
+++ b/firstboot.sh
@@ -6,21 +6,17 @@ if [ ! -z "${macadd}" ]; then
   sed "s/raspberrypi/${macadd}/g" -i /etc/hostname /etc/hosts
 fi
 
-# FIXME : Put all theses rapi-config in another bash script `raspi-config.sh.example`
-# Set a conditionnal launch only if `raspi-config.sh` exist here.
+# You can customise the system here :
+# Put the minimal stuff, prefer to use ansible to install/configure yours raspberry !
+sudo apt update && apt upgrade -y
+sudo apt install -y raspi-config
 
-# set boot options
-# sudo raspi-config nonint do_boot_behaviour B1 # Boot to CLI & require login
-# sudo raspi-config nonint do_boot_wait 0       # Turn off waiting for network before booting
-# sudo raspi-config nonint do_memory_split 16   # Set the GPU memory limit to 16MB
+sudo raspi-config nonint do_boot_behaviour B1 # Boot to cli (no  gui) & require login (no autologin)
+sudo raspi-config nonint do_boot_wait 0       # Turn off waiting for network before booting
 
-# System Configuration. Can also be done after with ansible
+# Other system configuration examples :
 # sudo raspi-config nonint do_change_timezone Europe/Paris
 # sudo raspi-config nonint do_change_locale fr_FR.UTF-8
 # sudo raspi-config nonint do_configure_keyboard fr
-
-# upgrade packages and set hostname
-# sudo apt update && upgrade -y
-# sudo apt install -y raspi-config vim
 
 /sbin/shutdown -r 5 "reboot in Five minutes"

--- a/firstboot.sh
+++ b/firstboot.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
 sleep 2m
-macadd=$( ip -brief add | awk '/UP/ {print $1}' | sort | head -1 )
-if [ ! -z "${macadd}" ]
-then
-  macadd=$( sed 's/://g' /sys/class/net/${macadd}/address )
+macadd=$(ip -brief add | awk '/UP/ {print $1}' | sort | head -1)
+if [ ! -z "${macadd}" ]; then
+  macadd=$(sed 's/://g' /sys/class/net/${macadd}/address)
   sed "s/raspberrypi/${macadd}/g" -i /etc/hostname /etc/hosts
 fi
+
+# FIXME : Put all theses rapi-config in another bash script `raspi-config.sh.example`
+# Set a conditionnal launch only if `raspi-config.sh` exist here.
+
+# set boot options
+# sudo raspi-config nonint do_boot_behaviour B1 # Boot to CLI & require login
+# sudo raspi-config nonint do_boot_wait 0       # Turn off waiting for network before booting
+# sudo raspi-config nonint do_memory_split 16   # Set the GPU memory limit to 16MB
+
+# System Configuration. Can also be done after with ansible
+# sudo raspi-config nonint do_change_timezone Europe/Paris
+# sudo raspi-config nonint do_change_locale fr_FR.UTF-8
+# sudo raspi-config nonint do_configure_keyboard fr
+
+# upgrade packages and set hostname
+# sudo apt update && upgrade -y
+# sudo apt install -y raspi-config vim
+
 /sbin/shutdown -r 5 "reboot in Five minutes"

--- a/fix-ssh-on-pi.bash
+++ b/fix-ssh-on-pi.bash
@@ -65,7 +65,6 @@ variables=(
     pi_password_hash
     public_key_file
     wifi_file
-    os_variant
 )
 
 for variable in "${variables[@]}"; do
@@ -75,15 +74,10 @@ for variable in "${variables[@]}"; do
     fi
 done
 
-if [[ "${os_variant}" != @(lite|full) ]]; then
-    echo "ERROR: wrong os_variant : ${os_variant}. it must be either 'lite', either 'full'."
-    exit 2
-fi
-
-image_to_download="https://downloads.raspberrypi.org/raspios_${os_variant}_armhf_latest"
-url_base="https://downloads.raspberrypi.org/raspios_${os_variant}_armhf/images/"
-version="$(wget -q ${url_base} -O - | awk -F '"' -v pattern="raspios_${os_variant}_armhf-" '$0 ~ pattern {print $8}' - | sort -nr | head -1)"
-sha_file=$(wget -q ${url_base}/${version} -O - | awk -F '"' -v pattern="armhf-${os_variant}.zip.sha256" '$0 ~ pattern {print $8}' -)
+image_to_download="https://downloads.raspberrypi.org/raspios_full_armhf_latest"
+url_base="https://downloads.raspberrypi.org/raspios_full_armhf/images/"
+version="$(wget -q ${url_base} -O - | awk -F '"' '/raspios_full_armhf-/ {print $8}' - | sort -nr | head -1)"
+sha_file=$(wget -q ${url_base}/${version} -O - | awk -F '"' '/armhf-full.zip.sha256/ {print $8}' -)
 sha_sum=$(wget -q "${url_base}/${version}/${sha_file}" -O - | awk '{print $1}')
 sdcard_mount="/mnt/sdcard"
 
@@ -143,7 +137,7 @@ echo "Mounting the sdcard boot disk"
 loop_base=$(losetup --partscan --find --show "${extracted_image}")
 
 echo "Running: mount ${loop_base}p1 \"${sdcard_mount}\" "
-mount "${loop_base}p1" "${sdcard_mount}"
+mount ${loop_base}p1 "${sdcard_mount}"
 ls -al "$sdcard_mount"
 if [ ! -e "${sdcard_mount}/kernel.img" ]; then
     echo "Can't find the mounted card\"${sdcard_mount}/kernel.img\""
@@ -170,11 +164,11 @@ umount_sdcard
 
 echo "Mounting the sdcard root disk"
 echo "Running: mount ${loop_base}p2 \"${sdcard_mount}\" "
-mount "${loop_base}p2" "${sdcard_mount}"
+mount ${loop_base}p2 "${sdcard_mount}"
 ls -al "$sdcard_mount"
+
 if [ ! -e "${sdcard_mount}/etc/shadow" ]; then
     echo "Can't find the mounted card\"${sdcard_mount}/etc/shadow\""
-    losetup --detach ${loop_base}
     exit 10
 fi
 

--- a/fix-ssh-on-pi.bash
+++ b/fix-ssh-on-pi.bash
@@ -1,17 +1,17 @@
 #!/bin/bash
-# MIT License 
+# MIT License
 # Copyright (c) 2017 Ken Fallon http://kenfallon.com
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,7 +26,7 @@
 #        Added support for wifi mac naming (Thanks danielo515)
 #        Moved ethernet naming to firstboot.sh
 # v1.4 - Removed option to encrypt clear password. It's more secure to keep store
-#        the hash anyway. Thanks tillhanke 
+#        the hash anyway. Thanks tillhanke
 
 # Credits to:
 # - http://hackerpublicradio.org/correspondents.php?hostid=225
@@ -36,75 +36,72 @@
 # Change the settings in the file mentioned below.
 
 function check_tool() {
-  command -v "${1}" >/dev/null 2>&1
-  if [[ ${?} -ne 0 ]]
-  then
-    echo "ERROR: Can't find the application \"${1}\" installed on your system."
-    exit 11
-  fi
+    command -v "${1}" >/dev/null 2>&1
+    if [[ ${?} -ne 0 ]]; then
+        echo "ERROR: Can't find the application \"${1}\" installed on your system."
+        exit 11
+    fi
 }
 
-for this_tool in 7z awk cat cd chmod chown cp echo exit grep head id ln losetup ls lsblk mkdir mount sed sha256sum sort wc wget
-do
-  check_tool "${this_tool}"
+for this_tool in 7z awk cat cd chmod chown cp echo exit grep head id ln losetup ls lsblk mkdir mount sed sha256sum sort wc wget; do
+    check_tool "${this_tool}"
 done
 
 settings_file="fix-ssh-on-pi.ini"
 
-if [ -e "${settings_file}" ]
-then
-  source "${settings_file}"
-elif [ -e "${HOME}/${settings_file}" ]
-then
-  source "${HOME}/${settings_file}"
-elif [ -e "${0%.*}.ini" ]
-then
-  source "${0%.*}.ini"
+if [ -e "${settings_file}" ]; then
+    source "${settings_file}"
+elif [ -e "${HOME}/${settings_file}" ]; then
+    source "${HOME}/${settings_file}"
+elif [ -e "${0%.*}.ini" ]; then
+    source "${0%.*}.ini"
 else
-  echo "ERROR: Can't find the Settings file \"${settings_file}\""
-  exit 1
+    echo "ERROR: Can't find the Settings file \"${settings_file}\""
+    exit 1
 fi
 
 variables=(
-  root_password_hash
-  pi_password_hash
-  public_key_file
-  wifi_file
+    root_password_hash
+    pi_password_hash
+    public_key_file
+    wifi_file
+    os_variant
 )
 
-for variable in "${variables[@]}"
-do
-  if [[ -z ${!variable+x} ]]; then   # indirect expansion here
-    echo "ERROR: The variable \"${variable}\" is missing from your \""${settings_file}"\" file.";
-    exit 2
-  fi
+for variable in "${variables[@]}"; do
+    if [[ -z ${!variable+x} ]]; then # indirect expansion here
+        echo "ERROR: The variable \"${variable}\" is missing from your \""${settings_file}"\" file."
+        exit 2
+    fi
 done
 
-image_to_download="https://downloads.raspberrypi.org/raspios_full_armhf_latest"
-url_base="https://downloads.raspberrypi.org/raspios_full_armhf/images/"
-version="$( wget -q ${url_base} -O - | awk -F '"' '/raspios_full_armhf-/ {print $8}' - | sort -nr | head -1 )"
-sha_file=$( wget -q ${url_base}/${version} -O - | awk -F '"' '/armhf-full.zip.sha256/ {print $8}' - )
-sha_sum=$( wget -q "${url_base}/${version}/${sha_file}" -O - | awk '{print $1}' )
+if [[ "${os_variant}" != @(lite|full) ]]; then
+    echo "ERROR: wrong os_variant : ${os_variant}. it must be either 'lite', either 'full'."
+    exit 2
+fi
+
+image_to_download="https://downloads.raspberrypi.org/raspios_${os_variant}_armhf_latest"
+url_base="https://downloads.raspberrypi.org/raspios_${os_variant}_armhf/images/"
+version="$(wget -q ${url_base} -O - | awk -F '"' -v pattern="raspios_${os_variant}_armhf-" '$0 ~ pattern {print $8}' - | sort -nr | head -1)"
+sha_file=$(wget -q ${url_base}/${version} -O - | awk -F '"' -v pattern="armhf-${os_variant}.zip.sha256" '$0 ~ pattern {print $8}' -)
+sha_sum=$(wget -q "${url_base}/${version}/${sha_file}" -O - | awk '{print $1}')
 sdcard_mount="/mnt/sdcard"
 
-if [ $(id | grep 'uid=0(root)' | wc -l) -ne "1" ]
-then
+if [ $(id | grep 'uid=0(root)' | wc -l) -ne "1" ]; then
     echo "You are not root "
     exit
 fi
 
-if [ ! -e "${public_key_file}" ]
-then
+if [ ! -e "${public_key_file}" ]; then
     echo "Can't find the public key file \"${public_key_file}\""
     echo "You can create one using:"
     echo "   ssh-keygen -t ed25519 -f ./${public_key_file} -C \"Raspberry Pi keys\""
     exit 3
 fi
 
-function umount_sdcard () {
+function umount_sdcard() {
     umount "${sdcard_mount}"
-    if [ $( ls -al "${sdcard_mount}" | wc -l ) -eq "3" ]
-    then
+    if [ $(ls -al "${sdcard_mount}" | wc -l) -eq "3" ]; then
         echo "Sucessfully unmounted \"${sdcard_mount}\""
         sync
     else
@@ -118,27 +115,24 @@ wget --continue ${image_to_download} -O raspbian_image.zip
 
 echo "Checking the SHA-1 of the downloaded image matches \"${sha_sum}\""
 
-if [ $( sha256sum raspbian_image.zip | grep ${sha_sum} | wc -l ) -eq "1" ]
-then
+if [ $(sha256sum raspbian_image.zip | grep ${sha_sum} | wc -l) -eq "1" ]; then
     echo "The sha_sums match"
 else
     echo "The sha_sums did not match"
     exit 5
 fi
 
-if [ ! -d "${sdcard_mount}" ]
-then
-  mkdir ${sdcard_mount}
+if [ ! -d "${sdcard_mount}" ]; then
+    mkdir ${sdcard_mount}
 fi
 
 # unzip
-extracted_image=$( 7z l raspbian_image.zip | awk '/-raspios-/ {print $NF}' )
+extracted_image=$(7z l raspbian_image.zip | awk '/-raspios-/ {print $NF}')
 echo "The name of the image is \"${extracted_image}\""
 
 7z x -y raspbian_image.zip
 
-if [ ! -e ${extracted_image} ]
-then
+if [ ! -e ${extracted_image} ]; then
     echo "Can't find the image \"${extracted_image}\""
     exit 6
 fi
@@ -146,57 +140,52 @@ fi
 umount_sdcard
 echo "Mounting the sdcard boot disk"
 
-loop_base=$( losetup --partscan --find --show "${extracted_image}" )
+loop_base=$(losetup --partscan --find --show "${extracted_image}")
 
 echo "Running: mount ${loop_base}p1 \"${sdcard_mount}\" "
-mount ${loop_base}p1 "${sdcard_mount}"
+mount "${loop_base}p1" "${sdcard_mount}"
 ls -al "$sdcard_mount"
-if [ ! -e "${sdcard_mount}/kernel.img" ]
-then
+if [ ! -e "${sdcard_mount}/kernel.img" ]; then
     echo "Can't find the mounted card\"${sdcard_mount}/kernel.img\""
     exit 7
 fi
 
 cp -v "${wifi_file}" "${sdcard_mount}/wpa_supplicant.conf"
-if [ ! -e "${sdcard_mount}/wpa_supplicant.conf" ]
-then
+if [ ! -e "${sdcard_mount}/wpa_supplicant.conf" ]; then
     echo "Can't find the wpa_supplicant file \"${sdcard_mount}/wpa_supplicant.conf\""
     exit 8
 fi
 
 touch "${sdcard_mount}/ssh"
-if [ ! -e "${sdcard_mount}/ssh" ]
-then
+if [ ! -e "${sdcard_mount}/ssh" ]; then
     echo "Can't find the ssh file \"${sdcard_mount}/ssh\""
     exit 9
 fi
 
-if [ -e "${first_boot}" ]
-then
-  cp -v "${first_boot}" "${sdcard_mount}/firstboot.sh"
+if [ -e "${first_boot}" ]; then
+    cp -v "${first_boot}" "${sdcard_mount}/firstboot.sh"
 fi
 
 umount_sdcard
 
 echo "Mounting the sdcard root disk"
 echo "Running: mount ${loop_base}p2 \"${sdcard_mount}\" "
-mount ${loop_base}p2 "${sdcard_mount}"
+mount "${loop_base}p2" "${sdcard_mount}"
 ls -al "$sdcard_mount"
-
-if [ ! -e "${sdcard_mount}/etc/shadow" ]
-then
+if [ ! -e "${sdcard_mount}/etc/shadow" ]; then
     echo "Can't find the mounted card\"${sdcard_mount}/etc/shadow\""
+    losetup --detach ${loop_base}
     exit 10
 fi
 
 echo "Change the passwords and sshd_config file"
 
-sed -e "s#^root:[^:]\+:#root:${root_password_hash}:#" "${sdcard_mount}/etc/shadow" -e  "s#^pi:[^:]\+:#pi:${pi_password_hash}:#" -i "${sdcard_mount}/etc/shadow"
+sed -e "s#^root:[^:]\+:#root:${root_password_hash}:#" "${sdcard_mount}/etc/shadow" -e "s#^pi:[^:]\+:#pi:${pi_password_hash}:#" -i "${sdcard_mount}/etc/shadow"
 sed -e 's;^#PasswordAuthentication.*$;PasswordAuthentication no;g' -e 's;^PermitRootLogin .*$;PermitRootLogin no;g' -i "${sdcard_mount}/etc/ssh/sshd_config"
 mkdir "${sdcard_mount}/home/pi/.ssh"
 chmod 0700 "${sdcard_mount}/home/pi/.ssh"
 chown 1000:1000 "${sdcard_mount}/home/pi/.ssh"
-cat ${public_key_file} >> "${sdcard_mount}/home/pi/.ssh/authorized_keys"
+cat ${public_key_file} >>"${sdcard_mount}/home/pi/.ssh/authorized_keys"
 chown 1000:1000 "${sdcard_mount}/home/pi/.ssh/authorized_keys"
 chmod 0600 "${sdcard_mount}/home/pi/.ssh/authorized_keys"
 
@@ -213,7 +202,7 @@ Type=oneshot
 RemainAfterExit=no
 
 [Install]
-WantedBy=multi-user.target" > "${sdcard_mount}/lib/systemd/system/firstboot.service"
+WantedBy=multi-user.target" >"${sdcard_mount}/lib/systemd/system/firstboot.service"
 
 cd "${sdcard_mount}/etc/systemd/system/multi-user.target.wants" && ln -s "/lib/systemd/system/firstboot.service" "./firstboot.service"
 cd -

--- a/fix-ssh-on-pi.ini_example
+++ b/fix-ssh-on-pi.ini_example
@@ -1,8 +1,8 @@
 # Generate the password hash using `mkpasswd -m sha512crypt`
 #root_password_hash='changeme'
 #pi_password_hash='changeme'
-#public_key_file="/home/change_me/.ssh/id_ed25519_pi.pub"
-#wifi_file="/home/change_me/.ssh/wpa_supplicant.conf"
-first_boot="firstboot.sh"
-os_variant="full"
+#public_key_file='/home/change_me/.ssh/id_ed25519_pi.pub'
+#wifi_file='/home/change_me/.ssh/wpa_supplicant.conf'
+first_boot='firstboot.sh'
+os_variant='full'
 #ssh_port=22

--- a/fix-ssh-on-pi.ini_example
+++ b/fix-ssh-on-pi.ini_example
@@ -5,3 +5,4 @@
 #wifi_file="/home/change_me/.ssh/wpa_supplicant.conf"
 first_boot="firstboot.sh"
 os_variant="full"
+#ssh_port=22

--- a/fix-ssh-on-pi.ini_example
+++ b/fix-ssh-on-pi.ini_example
@@ -4,3 +4,4 @@
 #public_key_file="/home/change_me/.ssh/id_ed25519_pi.pub"
 #wifi_file="/home/change_me/.ssh/wpa_supplicant.conf"
 first_boot="firstboot.sh"
+os_variant="full"

--- a/wpa_supplicant.conf_example
+++ b/wpa_supplicant.conf_example
@@ -1,16 +1,16 @@
 # For more information see:
+# - https://www.daemon-systems.org/man/wpa_supplicant.conf.5.html
 # - https://linux.die.net/man/5/wpa_supplicant.conf
 # - https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md
 
-# Country can be mandatory to get network working
-# List here : https://datahub.io/core/country-list
+# The pathname of the directory in which wpa_supplicant creates UNIX domain socket files
 # ctrl_interface=/var/run/wpa_supplicant
-# country=FR
 # update_config=1
+# /!\ Country can be mandatory to have a working wifi network :
+# country=<Insert 2 letter ISO 3166-1 country code here (GB, FR, DE, US...)>  
 
 network={
-    scan_ssid=1
-    ssid="testing"
-    psk="testingPassword"
-    id_str="home"
+  scan_ssid=1
+  ssid="<Name of your wireless LAN>"
+  psk="<Password for your wireless LAN>"
 }

--- a/wpa_supplicant.conf_example
+++ b/wpa_supplicant.conf_example
@@ -2,7 +2,15 @@
 # - https://linux.die.net/man/5/wpa_supplicant.conf
 # - https://www.raspberrypi.org/documentation/configuration/wireless/wireless-cli.md
 
+# Country can be mandatory to get network working
+# List here : https://datahub.io/core/country-list
+# ctrl_interface=/var/run/wpa_supplicant
+# country=FR
+# update_config=1
+
 network={
+    scan_ssid=1
     ssid="testing"
     psk="testingPassword"
+    id_str="home"
 }


### PR DESCRIPTION
Hi,

Over internet, I searched for a simple way to burn a raspbian image with ssh enabled. Without the painful managing of mounting stuff and so on. And find that repo. Thanks for your amazing work on it !

Sadly, i'm on mac os so tool like `losetup` are not available, so it was not usable.
Also, i wanted a very simple way to use it and docker is my solution.

And BTW, I need to use a 'lite' version of the os. 

This PR solve both of my concerns : 

- Add an option to be able to choose between 'full' and 'lite' variant for raspbian os.
- Add instruction to the README to be able to create the ssh-enabled image with docker.

Note : the ugly option `-v /dev:/dev` seem to be needed (check [here](https://github.com/moby/moby/issues/27886) for more info). Without that, the `losetup` command does not successfully retrieve the partition table and create device.

Not sure if it's something that you'll want to be merged but I create the PR in case of. If someone on Mac encounter this problem : it can help. :)
