### PR TITLE
rename ini_example to ini, and include encrypted pw instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ In episode [hpr2356 :: Safely enabling ssh in the default Raspbian Image](http:/
 - Verify it is valid
 - Extract the image itself
 - Enable ssh for secure remote management
-- Change the default passwords for the root and pi user
+- Change the default passwords for the root and pi user  
+  Generate encrypted + shell escaped password string using `encrypted=$(openssl passwd -6) bash -c 'printf "%q\n" "${encrypted}"'`
 - Secure the ssh server on the Pi
 
 Since then I improved the script to:

--- a/fix-ssh-on-pi.bash
+++ b/fix-ssh-on-pi.bash
@@ -52,8 +52,8 @@ else
 fi
 
 variables=(
-  root_password_clear
-  pi_password_clear
+  root_password_encrypted
+  pi_password_encrypted
   public_key_file
   wifi_file
 )
@@ -177,9 +177,7 @@ fi
 
 echo "Change the passwords and sshd_config file"
 
-root_password="$( python3 -c "import crypt; print(crypt.crypt('${root_password_clear}', crypt.mksalt(crypt.METHOD_SHA512)))" )"
-pi_password="$( python3 -c "import crypt; print(crypt.crypt('${pi_password_clear}', crypt.mksalt(crypt.METHOD_SHA512)))" )"
-sed -e "s#^root:[^:]\+:#root:${root_password}:#" "${sdcard_mount}/etc/shadow" -e  "s#^pi:[^:]\+:#pi:${pi_password}:#" -i "${sdcard_mount}/etc/shadow"
+sed -e "s#^root:[^:]\+:#root:${root_password_encrypted}:#" "${sdcard_mount}/etc/shadow" -e  "s#^pi:[^:]\+:#pi:${pi_password_encrypted}:#" -i "${sdcard_mount}/etc/shadow"
 sed -e 's;^#PasswordAuthentication.*$;PasswordAuthentication no;g' -e 's;^PermitRootLogin .*$;PermitRootLogin no;g' -i "${sdcard_mount}/etc/ssh/sshd_config"
 mkdir "${sdcard_mount}/home/pi/.ssh"
 chmod 0700 "${sdcard_mount}/home/pi/.ssh"

--- a/fix-ssh-on-pi.ini
+++ b/fix-ssh-on-pi.ini
@@ -1,0 +1,5 @@
+root_password_encrypted="\$6\$SztiKXi5iDHrUgl7\$VChBXsW64HY3pSN/T4xpavMDAMdBvRDZXYUhwsMU5OGzKgSkLF3vJbpgapGriAse8dk9tTXAE8ctdoVXNGfb60"
+pi_password_encrypted="\$6\$SztiKXi5iDHrUgl7\$VChBXsW64HY3pSN/T4xpavMDAMdBvRDZXYUhwsMU5OGzKgSkLF3vJbpgapGriAse8dk9tTXAE8ctdoVXNGfb60"
+#public_key_file="/home/change_me/.ssh/id_ed25519_pi.pub"
+#wifi_file="/home/change_me/.ssh/wpa_supplicant.conf"
+first_boot="firstboot.sh"

--- a/fix-ssh-on-pi.ini_example
+++ b/fix-ssh-on-pi.ini_example
@@ -1,5 +1,0 @@
-#root_password_clear='changeme'
-#pi_password_clear='changeme'
-#public_key_file="/home/change_me/.ssh/id_ed25519_pi.pub"
-#wifi_file="/home/change_me/.ssh/wpa_supplicant.conf"
-first_boot="firstboot.sh"


### PR DESCRIPTION
The parameters file `fix-ssh-on-pi.ini_example` was presumably named this way so nobody would accidentally commit a plain text password to source control. This change renames that file to just `fix-ssh-on-pi.ini` and expects an _encrypted_ password to be put in there instead. This still prevents any reasonable user from committing plain passwords to source control, but it removes the extra step of having to copy the example file to a "real" one.

The readme has been extended with instructions on how to generate an encrypted password string (which leads to a shell escaped output string). This method also prevents plain passwords from ending up in anyone's shell history.