### PR TITLE
Bullseye related changes

### DIFF
--- a/fix-ssh-on-pi.bash
+++ b/fix-ssh-on-pi.bash
@@ -44,7 +44,7 @@ function check_tool() {
   fi
 }
 
-for this_tool in awk cat cd chmod chown cp echo exit grep head id ln losetup ls lsblk mkdir mount sed sha256sum sort wc wget
+for this_tool in unxz awk cat cd chmod chown cp echo exit grep head id ln losetup ls lsblk mkdir mount sed sha256sum sort wc wget
 do
   check_tool "${this_tool}"
 done

--- a/fix-ssh-on-pi.ini_example
+++ b/fix-ssh-on-pi.ini_example
@@ -1,6 +1,8 @@
-# Generate the password hash using `mkpasswd -m sha512crypt`
+# Generate the root password hash using `mkpasswd -m sha512crypt`
+# Generate username password hash using `echo 'mypassword' | openssl passwd -6 -stdin`
 #root_password_hash='changeme'
-#pi_password_hash='changeme'
+#username='new_username'
+#user_password_hash='changeme'
 #public_key_file="/home/change_me/.ssh/id_ed25519_pi.pub"
 #wifi_file="/home/change_me/.ssh/wpa_supplicant.conf"
 first_boot="firstboot.sh"


### PR DESCRIPTION
Hey folks,
The newest version of Raspberry Pi OS Bullseye (7th April 2022) now demands to specify another user than standard user pi. Other than that, the os file system changed from *.zip to *.xz. I made a few changes to solve these problems which were no longer compatible with the current version of the scripts.

Thanks @kenfallon for these great scripts, have been using them a lot lately!